### PR TITLE
fix:update cognito stack to use standard proctection mode

### DIFF
--- a/src/lib/cognito.ts
+++ b/src/lib/cognito.ts
@@ -45,7 +45,7 @@ export default class CognitoResources extends Construct {
         requireDigits: true,
         requireSymbols: true,
       },
-      advancedSecurityMode: cognito.AdvancedSecurityMode.ENFORCED,
+      standardThreatProtectionMode: cognito.StandardThreatProtectionMode.FULL_FUNCTION,
     });
 
     this.userPoolClient = new cognito.UserPoolClient(


### PR DESCRIPTION
*Issue #16 , if available:*

*Description of changes:*
Fix Cognito stack in CDK to support standardThreatProtectionMode instead of depreceated Advanced security.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
